### PR TITLE
Clarify problem list on /about

### DIFF
--- a/src/markdown-pages/about_Galasa.md
+++ b/src/markdown-pages/about_Galasa.md
@@ -7,6 +7,8 @@ Galasa is an open source deep integration test framework for teams looking to gi
 
 Galasa has been architected to ensure that the routine tasks of writing and executing tests are straightforward. The more complex parts of tests (such as provisioning) are abstracted into other components that can be written by experts and easily distributed to the team.
 
+## Which of these problems do you recognise?
+
 If you've ever struggled to implement automated testing across a complex technology stack, you might recognize some of the same symptoms we identified during our design process:
 
 <details>


### PR DESCRIPTION
The /about page needs to be more clear that Galasa provides a solution to the pain points listed.