### PR TITLE
Late-breaking pre-release (0.5.0) edits

### DIFF
--- a/src/markdown-pages/docs/managers.md
+++ b/src/markdown-pages/docs/managers.md
@@ -40,7 +40,6 @@ title: "Managers"
 | **Artifactory Manager** | Provides the ability to retrieve artifacts from Artifactory servers. |
 | **CECI Manager** | Provides CECI 3270 interaction - initially supporting containers and link programs.|
 | **CEMT Manager** | Provides CEMT 3270 interaction.|
-| **CICS SFR Manager** | Configures Service Flow Runtime instances in CICS TS servers.|
 | **CICS TS Manager** | Provides configuration information for pre-existing CICS TS servers. Drives provisioning services from other managers, e.g. z/OS PT.|
 | **CICS z/OS PT Provisioning Manager** | Provisions CICS TS servers for the CICS TS Manager.|
 | **GitHub Manager** | Enables tests to retrieve artifacts from GitHub and enables test results to be influenced by the status of issues.|

--- a/src/markdown-pages/docs/running-simbank-tests.md
+++ b/src/markdown-pages/docs/running-simbank-tests.md
@@ -13,6 +13,8 @@ All of these example tests become available when you set up a Galasa example pro
 
 ## Creating an example Galasa project
 
+<b>NOTE:</b> Normally m2e (the Eclipse Maven plug-in) automatically compiles the test bundles and produces the necessary manifest and OSGi files. However, there appears to be an anomaly in m2e in the 2019 versions of Eclipse which we are investigating.   If the bundles fail to build correctly, you can force the Maven build by right-clicking the *project* and selecting *Run As > Maven Install*.  We will resolve this issue for 0.5.0.
+
 1. Ensure that Eclipse is running.
 1. Choose *File > New > Example*, select *SimBank example projects* and press *Next*.
 1. Confirm your *New project* prefix (it's OK to leave it as `dev.galasa.simbank`) and press *Finish*. In your *Package Explorer* (if it's not visible, choose *Window > Show View > Package Explorer*), two new entries appear:


### PR DESCRIPTION
1. Removed SFR manager from list of future managers.
2. Added cautionary note about Maven>Install as per MB advice.