### PR TITLE
Missing/Incorrect CPS properties which null out to default values fixed

### DIFF
--- a/src/markdown-pages/docs/first-steps/installing.md
+++ b/src/markdown-pages/docs/first-steps/installing.md
@@ -65,8 +65,9 @@ dss.properties
 
     zos.image.SIMBANK.ipv4.hostname=127.0.0.1
     zos.image.SIMBANK.telnet.port=2023
+    zos.image.SIMBANK.webnet.port=2080
     zos.image.SIMBANK.telnet.tls=false
-    zos.image.SIMBANK.credentials=SIMBANK
+    zos.image.SIMBANK.credentials.id=SIMBANK
 
     zosmf.server.SIMBANK.images=SIMBANK
     zosmf.server.SIMBANK.hostname=127.0.0.1


### PR DESCRIPTION
Webnet port never defined in CPS, this has just nulled in the manager to give the default (correct) value. This cps property should be present.
Credentials cps property should be found using the suffix credentials.id. This cps property is nulling out to the correct deafult value as well but should be correct.