### PR TITLE
Run a maximum of 1 deploy at a time to avoid site downtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
             vars-file: vars.london.yml
           - api: api.au-syd.cf.cloud.ibm.com
             vars-file: vars.sydney.yml
+      max-parallel: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This returns to rolling through deployments one at a time (the first deployment using Actions resulted in downtime because all sites were down at once).

Given we deploy to 3 sites, we could push this up to 2 in parallel - however, if there's a failure to deploy that will leave us with 2 sites requiring backout rather than a single one. I feel like uptime wins out over speed and consistency of deployment in this case.