### PR TITLE
Allow overriding host, port with env vars

### DIFF
--- a/package-jar/build.gradle
+++ b/package-jar/build.gradle
@@ -18,7 +18,7 @@ liberty {
     server {
         name = 'galasaServer'
 
-        bootstrapProperties = [
+        defaultVar = [
                 'server.http.port':'9080',
                 'server.http.host':'localhost',
         ]


### PR DESCRIPTION
This change allows the properties to be overridden with environment variables, not just system properties - for example:

```
SERVER_HTTP_PORT=9082 java -jar .../galasa.dev-runnable.jar
```