### PR TITLE
Use the central CF deploy plugin again now my PR is merged

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,8 +87,7 @@ jobs:
         run: cp -av repo/cf/. site/
 
       - name: Deploy to IBM Cloud
-        # uses: IBM/cloudfoundry-deploy@v2.0
-        uses: ind1go/cloudfoundry-deploy@vars-file
+        uses: IBM/cloudfoundry-deploy@v2.1
         with:
           IBM_CLOUD_API_KEY: ${{ secrets.IBM_CLOUD_API_KEY }}
           IBM_CLOUD_CF_API: ${{ matrix.region.api }}


### PR DESCRIPTION
I was previously using a personal version of the `IBM/cloudfoundry-deploy` action, which supported vars files. My PR to support that is now closed (IBM/cloudfoundry-deploy#8) so we can revert to the main action.