### PR TITLE
Move cookie preferences button to our own footer

### DIFF
--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -7,7 +7,7 @@ import Identifier from "../identifier/identifier"
 import GitHubSVG from "../../images/github.inline.svg"
 import TwitterSVG from "../../images/twitter.inline.svg"
 import SlackSVG from "../../images/slack.inline.svg"
-import { footer, identifier, links, icon } from "./footer.module.scss"
+import { footer, identifier, links, icon, cookieConsent } from "./footer.module.scss"
 
 const Footer = () => {
   const {
@@ -38,6 +38,7 @@ const Footer = () => {
       <div className={links}>
         <a href="https://www.ibm.com/privacy/us/en/">Privacy policy</a>
         <a href="https://www.ibm.com/legal">Terms of use</a>
+        <span className={cookieConsent} id="teconsent"></span>
       </div>
       <div>An open source project by IBM. Built in Hursley, UK.</div>
       <div>

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -7,7 +7,13 @@ import Identifier from "../identifier/identifier"
 import GitHubSVG from "../../images/github.inline.svg"
 import TwitterSVG from "../../images/twitter.inline.svg"
 import SlackSVG from "../../images/slack.inline.svg"
-import { footer, identifier, links, icon, cookieConsent } from "./footer.module.scss"
+import {
+  footer,
+  identifier,
+  links,
+  icon,
+  cookieConsent,
+} from "./footer.module.scss"
 
 const Footer = () => {
   const {

--- a/src/components/footer/footer.module.scss
+++ b/src/components/footer/footer.module.scss
@@ -61,7 +61,7 @@ $footer-height: 27rem;
 
 .cookieConsent {
   display: flex !important; // Fight TrustArc's CSS
-  
+
   a {
     text-transform: lowercase;
 

--- a/src/components/footer/footer.module.scss
+++ b/src/components/footer/footer.module.scss
@@ -58,3 +58,15 @@ $footer-height: 27rem;
     width: 30px;
   }
 }
+
+.cookieConsent {
+  display: flex !important; // Fight TrustArc's CSS
+  
+  a {
+    text-transform: lowercase;
+
+    &::first-letter {
+      text-transform: uppercase;
+    }
+  }
+}


### PR DESCRIPTION
Removes the odd-looking fixed-position cookie preferences button, instead getting that functionality attached to a true footer button.