### PR TITLE
Performance improvements to font loading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm run serve &
 
       - name: Check for broken links
-        run: npx broken-link-checker -ro --exclude /docs/managers/ --filter-level 3 --host-requests 8 --user-agent Chrome/90 --exclude https://github.com/galasa-dev/extensions/ http://localhost:9000
+        run: npx broken-link-checker -ro --exclude /docs/managers/ --filter-level 3 --host-requests 8 --user-agent Chrome/90 --exclude https://fonts.gstatic.com/ --exclude https://github.com/galasa-dev/extensions/ http://localhost:9000
 
       - name: Upload raw site
         uses: actions/upload-artifact@v2
@@ -144,7 +144,7 @@ jobs:
         run: npm run serve &
 
       - name: Check for broken links
-        run: npx broken-link-checker -ro --exclude /docs/managers/ --filter-level 3 --host-requests 8 --user-agent Chrome/90 --exclude https://github.com/galasa-dev/extensions/ http://localhost:9000
+        run: npx broken-link-checker -ro --exclude /docs/managers/ --filter-level 3 --host-requests 8 --user-agent Chrome/90 --exclude https://fonts.gstatic.com/ --exclude https://github.com/galasa-dev/extensions/ http://localhost:9000
 
       - name: Upload raw site
         uses: actions/upload-artifact@v2

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,6 +2,7 @@ const path = require(`path`)
 const crypto = require(`crypto`)
 
 const digitalData = require("./src/utils/digital-data")
+const lazyFontsScript = require("./src/components/layout/lazyFonts")
 
 const consts = {
   githubRepoName: "galasa.dev",
@@ -23,9 +24,9 @@ const buildRepoSlug = process.env.PR_REPO_SLUG || process.env.BASE_REPO_SLUG || 
 consts.buildRepoUrl = `https://github.com/${buildRepoSlug}`
 consts.buildBranch = process.env.PR_BRANCH_NAME || process.env.BRANCH_NAME || "main"
 
-function getDigitaDataHash() {
+function createHash(value) {
   if (process.env.GATSBY_GALASA_ENV !== "LOCAL") {
-    return `'sha256-${crypto.createHash('sha256').update(digitalData).digest('base64')}'`
+    return `'sha256-${crypto.createHash('sha256').update(value).digest('base64')}'`
   } else {
     return ''
   }
@@ -136,7 +137,7 @@ module.exports = {
         mergeStyleHashes: false,
         directives: {
           "style-src": "'unsafe-inline' https://fonts.googleapis.com",
-          "script-src": `'self' https://*.www.s81c.com https://*.ibm.com tags.tiqcdn.com consent.truste.com https://scripts.demandbase.com https://www.googletagmanager.com https://pixel.mathtag.com https://*.tealiumiq.com https://consent.trustarc.com https://cdn.trackjs.com https://dpm.demdex.net https://www.google-analytics.com ${getDigitaDataHash()}`,
+          "script-src": `'self' 'unsafe-hashes' https://*.www.s81c.com https://*.ibm.com tags.tiqcdn.com consent.truste.com https://scripts.demandbase.com https://www.googletagmanager.com https://pixel.mathtag.com https://*.tealiumiq.com https://consent.trustarc.com https://cdn.trackjs.com https://dpm.demdex.net https://www.google-analytics.com ${createHash(digitalData)} ${createHash(lazyFontsScript)}`,
           "font-src": "'self' data: https://fonts.gstatic.com https://*.www.s81c.com",
           "connect-src": "'self' https://*.ibm.com https://dbdm-events.mybluemix.net https://*.algolia.net https://*.algolianet.com https://dpm.demdex.net https://*.tealiumiq.com https://api.company-target.com https://www.google-analytics.com https://stats.g.doubleclick.net",
           "img-src": "'self' data: https://consent.trustarc.com https://id.rlcdn.com https://www.google-analytics.com https://cm.everesttech.net https://pixel.mathtag.com https://dpm.demdex.net https://sync.crwdcntrl.net",

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -16,6 +16,9 @@ import {
   container,
 } from "./layout.module.scss"
 
+const fontsUrl =
+  "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;1,400&family=Work+Sans:wght@400;500;600&family=IBM+Plex+Mono&display=swap"
+
 const Layout = ({ children, location: { pathname } }) => {
   const frontPage = pathname === "/"
   const extraHeightHeader = !frontPage
@@ -36,17 +39,19 @@ const Layout = ({ children, location: { pathname } }) => {
     <>
       <Helmet>
         <link
-          href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600&display=swap"
-          rel="stylesheet"
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
         />
         <link
-          href="https://fonts.googleapis.com/css?family=Work+Sans:400,500,600&display=swap"
+          href={fontsUrl}
           rel="stylesheet"
+          media="print"
+          onload="this.onload=null;this.removeAttribute('media');"
         />
-        <link
-          href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono&display=swap"
-          rel="stylesheet"
-        />
+        <noscript>{`
+          <link rel="stylesheet" href="${fontsUrl}" />
+        `}</noscript>
         <html className={globalStyle} />
         <body />
       </Helmet>

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -15,6 +15,7 @@ import {
   globalStyle,
   container,
 } from "./layout.module.scss"
+import lazyFontsScript from "./lazyFonts"
 
 const fontsUrl =
   "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;1,400&family=Work+Sans:wght@400;500;600&family=IBM+Plex+Mono&display=swap"
@@ -47,7 +48,7 @@ const Layout = ({ children, location: { pathname } }) => {
           href={fontsUrl}
           rel="stylesheet"
           media="print"
-          onload="this.onload=null;this.removeAttribute('media');"
+          onload={lazyFontsScript}
         />
         <noscript>{`
           <link rel="stylesheet" href="${fontsUrl}" />

--- a/src/components/layout/lazyFonts.js
+++ b/src/components/layout/lazyFonts.js
@@ -1,0 +1,3 @@
+const lazyFontsScript = "this.onload=null;this.removeAttribute('media');"
+
+module.exports = lazyFontsScript


### PR DESCRIPTION
Take loading the Google Fonts CSS file off the render-blocking path.
Preconnect to https://fonts.gstatic.com.
Use new `css2` endpoint to reduce number of resources.