### PR TITLE
Spelling mistake in main greeting index page.

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -90,7 +90,7 @@ const keyFeatures = [
       <>
         Galasa is open source, so can be extended to support additional tooling
         with no vendor lock-in and no initial cost. The framework supports
-        enterprise level through put, as the test workload can be scaled
+        enterprise level throughput, as the test workload can be scaled
         horizontally in its own cloud environment.
       </>
     ),


### PR DESCRIPTION
Throughput is a word, "through put" seems wrong.