### PR TITLE
Add . to end of docker image build

### DIFF
--- a/src/markdown-pages/docs/running-simbank-tests/web-app-integration-test.md
+++ b/src/markdown-pages/docs/running-simbank-tests/web-app-integration-test.md
@@ -74,7 +74,7 @@ Complete the following steps to build a Docker image to use in the test. We plan
 	1. Build the image and test that the container is working correctly by running the following commands. For the commands to work, the terminal must be running in the same directory as the one that contains the Dockerfile. The Dockerfile is located in the [galasa-simplatform-webapp directory](https://github.com/galasa-dev/simplatform/tree/main/galasa-simplatform-application/galasa-simplatform-webapp) in the Galasa `simplatform` repository.
 	```
 	mvn install
-	docker image build -t simbank-webapp 
+	docker image build -t simbank-webapp .
 	docker run -p 8080:8080 -d simbank-webapp
 	```
 


### PR DESCRIPTION
Following conversations in slack I've added the missing . to the end of the cocker image build command to ensure that when copied it doesn't cause an error.