### PR TITLE
add temporary sdv manager page

### DIFF
--- a/src/markdown-pages/docs/managers/sdv-manager.md
+++ b/src/markdown-pages/docs/managers/sdv-manager.md
@@ -1,0 +1,14 @@
+---
+path: "/docs/managers/sdv-manager"
+title: "SDV Manager"
+---
+
+This Manager is currently in development.<br>
+
+[Overview](#overview)<br>
+
+# <a name="overview"></a>Overview
+
+Create an automated integration test in Galasa and use the SDV Manager to obtain a report of the Security Definitions that would have been required if **Resource Security** and **Command Security** were turned on.
+
+Coming soon...


### PR DESCRIPTION
The CICS 6.2 docs want to link to the upcoming SDV manager documentation (proposed changes in https://github.com/galasa-dev/galasa.dev/pull/788).
However, I don't think those docs will be merged before the CICS 6.2 docs need to be released, so they are currently linking to a 404 page.
This PR delivers a basic page for the SDV manager, simply saying `Coming soon...`, which stops the 404.