### PR TITLE
Update upload-artifact version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         run: npx broken-link-checker -ro --exclude /docs/managers/ --filter-level 3 --host-requests 8 --user-agent Chrome/90 --exclude https://fonts.gstatic.com/ --exclude https://github.com/galasa-dev/extensions/ http://localhost:9000
 
       - name: Upload raw site
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: output-dotdev-raw-site
           path: public
@@ -72,7 +72,7 @@ jobs:
           path: repo
 
       - name: Download raw site
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: output-dotdev-raw-site
           path: site/public
@@ -211,7 +211,7 @@ jobs:
         run: npx broken-link-checker -ro --exclude /docs/managers/ --filter-level 3 --host-requests 8 --user-agent Chrome/90 --exclude https://fonts.gstatic.com/ --exclude https://github.com/galasa-dev/extensions/ http://localhost:9000
 
       - name: Upload raw site
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: output-local-raw-site
           path: public
@@ -220,7 +220,7 @@ jobs:
         run: ./.github/scripts/war.sh
 
       - name: Upload WAR
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: output-local-war
           path: galasa.dev-site.war
@@ -239,7 +239,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download WAR
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: output-local-war
       
@@ -261,7 +261,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload JAR
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: output-local-jar
           path: package-jar/build/libs/galasa.dev-runnable.jar


### PR DESCRIPTION
v3 has been removed and builds are failing as a result https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/