### PR TITLE
Iss2213 - Docs for TestResultProvider

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         run: npm run serve &
 
       - name: Check for broken links
-        run: npx broken-link-checker -ro --exclude /docs/managers/ --filter-level 3 --host-requests 8 --user-agent Chrome/90 --exclude https://fonts.gstatic.com/ --exclude https://github.com/galasa-dev/extensions/ --exclude https://*.algolia.net/ http://localhost:9000
+        run: npx broken-link-checker -ro --exclude /docs/managers/ --filter-level 3 --host-requests 2 --user-agent Chrome/90 --exclude https://fonts.gstatic.com/ --exclude https://github.com/galasa-dev/extensions/ --exclude https://*.algolia.net/ http://localhost:9000
 
       - name: Upload raw site
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
@@ -208,7 +208,7 @@ jobs:
         run: npm run serve &
 
       - name: Check for broken links
-        run: npx broken-link-checker -ro --exclude /docs/managers/ --filter-level 3 --host-requests 8 --user-agent Chrome/90 --exclude https://fonts.gstatic.com/ --exclude https://github.com/galasa-dev/extensions/ --exclude https://*.algolia.net/ http://localhost:9000
+        run: npx broken-link-checker -ro --exclude /docs/managers/ --filter-level 3 --host-requests 2 --user-agent Chrome/90 --exclude https://fonts.gstatic.com/ --exclude https://github.com/galasa-dev/extensions/ --exclude https://*.algolia.net/ http://localhost:9000
 
       - name: Upload raw site
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/src/data/nav.yaml
+++ b/src/data/nav.yaml
@@ -87,6 +87,8 @@
               path: /docs/writing-own-tests/binding-tests
             - title: Key principles for writing tests
               path: /docs/writing-own-tests/key-principles
+            - title: Controlling code execution after test failure
+              path: /docs/writing-own-tests/test-result-provider
         - title: The Galasa Ecosystem
           path: /docs/ecosystem
           items:

--- a/src/markdown-pages/docs/writing-own-tests/test-result-provider.md
+++ b/src/markdown-pages/docs/writing-own-tests/test-result-provider.md
@@ -1,0 +1,37 @@
+---
+path: "/docs/writing-own-tests/test-result-provider"
+title: "Controlling code execution after test failure"
+---
+
+As a tester, you may want the ability to access the result so far of a Galasa test at different points during the test lifecycle, to control the execution of code based on that result.
+
+The `ITestResultProvider` can be used to get the test result so far after the first method invokation in a test. It can give you access to if the test is in Passed or Failed state. You can then check the result so far in your test code and choose to call or not call non-test methods based on this.
+
+The annotation `@TestResultProvider` injects a `ITestResultProvider` object into your test class. The Core Manager updates the provider with the test result so far after each `@BeforeClass`, `@Before`, `@Test`, `@After` and `@AfterClass` method.
+
+To use this capability, simply include the lines of code below in your test:
+
+```java
+@TestResultProvider
+public ITestResultProvider testResultProvider;
+```
+
+In the example below, the `@AfterClass` method retrieves the result from the `ITestResultProvider` and checks if it is Failed. If the result is Failed, the method `myCustomCleanupMethod` is called which could contain some diagnostic collection or clean up of resources, which the tester only wants to be run if the test Failed.
+
+```java
+@AfterClass
+public void afterClassMethod() throws FrameworkException {
+    if (testResultProvider.getResult().isFailed()) {
+        myCustomCleanupMethod();
+    }
+}
+
+private void myCustomCleanupMethod() {
+    try {
+      // Some custom cleanup logic that only happens on failures.
+    } catch(Exception ex) {
+       logger.error("Failing while cleaning up in myCustomCleanupMethod()");
+       // Ignore the problem.
+    }
+}
+```

--- a/src/markdown-pages/docs/writing-own-tests/writing-test-classes.md
+++ b/src/markdown-pages/docs/writing-own-tests/writing-test-classes.md
@@ -18,7 +18,7 @@ Once loaded by the Galasa test runner, there are a few further annotations that 
 
 **`@Test`**
 <br>
-This annotation identifies a method as one that contains test code. Such methods are executed by Galasa by the order in which they appear in the test class - from top to bottom. If a test method fails, the following test methods are bypassed to encourage short, sharp parallel testing. This behaviour can be overridden using the `@StopOnError` annotation on the `class` statement.
+This annotation identifies a method as one that contains test code. Such methods are executed by Galasa by the order in which they appear in the test class - from top to bottom. If a test method fails, the following test methods are bypassed to encourage short, sharp parallel testing. This behaviour can be overridden using the `@ContinueOnTestFailure` annotation on the `class` statement.
 
 When a test method succeeds it is marked as PASSED, and if there is an exception it is marked FAILED. Managers can override this marking - for example, if a test throws a specific exception, a Manager could set the result to DISASTER.
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2213

Add documentation for controlling test execution based on the test result with the @TestResultProvider annotation.